### PR TITLE
Bump required python version to 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="new-flask-app",
-    version="1.0.1",
+    version="1.0.2",
     author="Philip Zhang",
     author_email="jmslca123@gmail.com",
     description="Autogenerate boilerplate code for a Flask app",
@@ -15,17 +15,17 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     classifiers=[
-        'Intended Audience :: Developers',
+        "Intended Audience :: Developers",
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
-    license='MIT',
-    install_requires=['PyInquirer', 'jinja2'],
+    python_requires=">=3.8",
+    license="MIT",
+    install_requires=["PyInquirer", "jinja2"],
     entry_points={
-        'console_scripts': [
-            'create-flask-app=create_flask_app.create_flask_app:prompt_user',
+        "console_scripts": [
+            "create-flask-app=create_flask_app.create_flask_app:prompt_user",
         ],
-    }
-    )
+    },
+)


### PR DESCRIPTION
# What
- bump python to 3.8
- fixes `copytree()` bug in #5 